### PR TITLE
Updated Developer Terms of Service in regard to Internal version

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -14,3 +14,4 @@ JSON
 UTF-8
 PNG
 versioning
+sublicense

--- a/chapters/intro/terms.md
+++ b/chapters/intro/terms.md
@@ -1,4 +1,4 @@
-This is the first version of the wavy.fm Developer Terms of Service. This version is effective October 7, 2020.
+This is the first version of the wavy.fm Developer Terms of Service. This version is effective October 11, 2020.
 
 ## Introduction
 
@@ -29,14 +29,39 @@ You must not use the developer platform to:
 
 1. infringe, facilitate infringing, or otherwise incite infringing our Terms of Service and Developer Terms of Service;
 2. promote, distribute, incite, or otherwise facilitate content infringing our Community Code of Conduct;
-3. promote, distribute, or develop commercial products without our express consent and permission; or
-4. circumvent restrictions imposed by us on your usage of the wavy.fm website or its developer platform.
+3. promote, distribute, or develop commercial products without our express consent and permission;
+4. target users with advertisements  or marketing; or
+5. provide services to children under the age of thirteen.
+
+While using the developer platform, you must not:
+
+1. modify a wavy.fm's user account or profile without their explicit and verifiable permission;
+2. retrieve or disclose any user's wavy.fm private data without their explicit and verifiable permission;
+3. circumvent restrictions imposed by us on your usage of the wavy.fm website or its developer platform;
+4. sublicense the API for use by a third-party;
+5. misrepresent or mask either your identity (or your application's identity);
+6. interfere or disrupt the API or the servers or networks that provide the developer platform; or
+7. reverse engineer or attempt to extract the source code from any API or any related software,
+   except to the extent that this restriction is expressly prohibited by applicable law;
+
+### Restrictions on Internal APIs
+
+In addition to the restrictions above, the following restrictions apply to **"internal"** portions of the
+developer platform as identified in the API Reference, or otherwise labeled as **"private"** or **"restricted"**.
+
+You must not use internal services of the developer platform to:
+
+1. provide a public service (as opposed to a service for personal use or for development) 
+   without our express consent and permission.
 
 ## Termination
 
 We reserve the right to modify, suspend or discontinue the wavy.fm developer platform,
 or to terminate your ability to use the developer platform, at any time, for any reason or for no reason,
 without any liability to you or your users.
+
+Our right to termination of your wavy.fm account as defined in the wavy.fm Terms of Service also extend to the
+developer platform.
 
 ## Users, Privacy, and Data
 

--- a/chapters/intro/terms.md
+++ b/chapters/intro/terms.md
@@ -42,7 +42,7 @@ While using the developer platform, you must not:
 5. misrepresent or mask either your identity (or your application's identity);
 6. interfere or disrupt the API or the servers or networks that provide the developer platform; or
 7. reverse engineer or attempt to extract the source code from any API or any related software,
-   except to the extent that this restriction is expressly prohibited by applicable law;
+   except to the extent that this restriction is expressly prohibited by applicable law.
 
 ### Restrictions on Internal APIs
 

--- a/chapters/reference/api.md
+++ b/chapters/reference/api.md
@@ -37,7 +37,9 @@ https://wavy.fm/api/internal
 
 The `internal` version is reserved for undocumented endpoints with the purpose of enhancing the wavy.fm website. There
 may be additional restrictions in the [Developer Terms of Service](../intro/terms) in regard to the Internal version.
-For example, you may not be able to develop a certain types of projects using this version.
+For example, you may not be able to develop a certain types of projects using this version. Note that all endpoints
+under origins other than `wavy.fm` are considered Internal: for example, `sentry.wavy.fm` and `api.wavy.fm` are Internal
+services.
 
 The latest version of the API is the recommended one to use in new and existing projects. You should
 migrate to new versions as soon as possible to prevent disruptions in your application. While we try to preserve


### PR DESCRIPTION
* Added additional restrictions to all applications in the Developer Terms of Service.
* Specified restrictions to applications using the `internal` version in the Developer ToS.
* Clarified that `api.wavy.fm` and other subdomains are considered internal.